### PR TITLE
+ plus4u.gr ad

### DIFF
--- a/void-gr-filters.txt
+++ b/void-gr-filters.txt
@@ -47,6 +47,7 @@ scdn.gr/images/helmet/promo_material/*
 ||static.reembed.com/data/logos/*
 ||argiro.gr/Images/Promotions/*
 ||www.thelosouvlakia.gr/cms/Uploads/ad/*
+||www.plus4u.gr/flash/plusilektrikes.swf
 adman.otenet.gr/*
 in.gr/banners/*
 banners.otenet.gr/banner/all_banners/*


### PR DESCRIPTION
ad banner is displayed in plus4u.gr internal pages, under left sidebar menu. 
eg. url:  www.plus4u.gr/category/hlektrikes-syskeyes 