### PR TITLE
Update soda cart reminder on e-food.gr

### DIFF
--- a/void-gr-filters.txt
+++ b/void-gr-filters.txt
@@ -806,7 +806,7 @@ onsports.gr###textlinks
 www.lifo.gr##a[href*="/lines/click/"]
 www.taxheaven.gr###main > .ads
 www.taxheaven.gr##.aside
-www.e-food.gr###coca-cola-btn
+www.e-food.gr##.cart-reminder
 www.eklogika.gr##.left_fixed
 www.eklogika.gr##.right_fixed
 voicenews.gr##.row.sidebar-nav


### PR DESCRIPTION
This PR hides an element that was hidden by [a previous PR](https://github.com/kargig/greek-adblockplus-filter/pull/25). I updated the rule since the website has been redesigned and it didn't work anymore.

`www.e-food.gr##.cart-reminder`:

This element appears above the products you have added in your basket when making an order and asks you if you forgot to add the soda in your order.

