### PR TITLE
Add rules for e-ptolemeos.gr

### DIFF
--- a/void-gr-filters.txt
+++ b/void-gr-filters.txt
@@ -425,6 +425,9 @@ ad.gr.doubleclick.net
 ||logotypos.gr/wp-content/uploads/2018/02/EKTYPOTIKH_LOW.jpg$image
 ||logotypos.gr/wp-content/uploads/2018/01/ektypotik3.gif$image
 ||protagon.gr/wp-content/uploads/2018/11/OPAP-NEW_Generic_3_174px-Protagon-1.jpg$image
+||e-ptolemeos.gr/*banner$image
+||e-ptolemeos.gr/*.gif$image
+||e-ptolemeos.gr/wp-content/uploads/2017/05/roi-eid-ban.jpg
 !Element-Hiding Rules
 www.insomnia.gr###ipbwrapper > .bgad[href="http://ads.nativad.net/servlet/click/zone?zid=351&pid=111&lookup=true&position=1&uuid=(email)"]
 www.insomnia.gr###ipbwrapper > .bgad[href="http://www.kotsovolos.gr/site/mobile-phones-gps/mobile-phones/smartphones?v=0&company=Apple&11202=44834&utm_source=insomnia.gr&utm_medium=skin&utm_content=NEWiphone6s-6splus-insomnia-skin-2015&utm_campaign=iphone6s-6splus-insomnia-"]
@@ -814,6 +817,18 @@ fonien.gr##.bdaia-bellow-header
 fonien.gr##.bdaia-custom-area > .bd-container > div
 fonien.gr##.bdaia-ad-container
 fonien.gr##.bdaia-widget-e3
+e-ptolemeos.gr##.background-cover
+e-ptolemeos.gr##.e3lan-top
+e-ptolemeos.gr##.afterheader
+e-ptolemeos.gr###custom_html-4
+e-ptolemeos.gr###custom_html-6
+e-ptolemeos.gr###custom_html-14
+e-ptolemeos.gr###custom_html-24
+e-ptolemeos.gr###custom_html-11
+e-ptolemeos.gr###custom_html-17
+e-ptolemeos.gr###custom_html-25
+e-ptolemeos.gr###custom_html-30
+e-ptolemeos.gr##.custom-html-widget
 ! Exception Rules
 @@sport-fm.gr/newspapers/$elemhide
 @@resources.sport-fm.gr/sportfm/newspapers/


### PR DESCRIPTION
Most credit goes to mapx-:
https://github.com/uBlockOrigin/uAssets/issues/4567#issuecomment-451887520

On [e-ptolemeos.gr](https://e-ptolemeos.gr/), this removes:
- The tiling background image
- The banner on the top right of the page
- The banners under the navbar
- The banners on the sidebar
- A self-advertisement under the article, when in an article page (`roi-eid-ban.jpg`)
- The `#custom_html-*` rules were containers for banners that are already blocked by the network filters, but leave some leftover borders.