### PR TITLE
Add rules for filadelfia-xalkidona.gr

### DIFF
--- a/void-gr-filters.txt
+++ b/void-gr-filters.txt
@@ -809,6 +809,10 @@ www.taxheaven.gr##.aside
 www.e-food.gr##.cart-reminder
 www.eklogika.gr##.left_fixed
 www.eklogika.gr##.right_fixed
+www.filadelfia-xalkidona.gr##.td_block_3
+www.filadelfia-xalkidona.gr##.td_block_16
+www.filadelfia-xalkidona.gr##.td-a-rec-id-content_top
+www.filadelfia-xalkidona.gr##.td-header-sp-rec
 voicenews.gr##.row.sidebar-nav
 fonien.gr##.bdaia-bellow-header
 fonien.gr##.bdaia-custom-area > .bd-container > div


### PR DESCRIPTION
On [filadelfia-xalkidona.gr](https://www.filadelfia-xalkidona.gr/), this hides:

- The two ad elements in the sidebar (`.td_block_*`)
- The banner above the content of an article, when viewing an article (`##.td-a-rec-id-content_top`)
- The banner on the top right of the page (`##.td-header-sp-rec`)

This closes #34 