### PR TITLE
Add rule for skroutz.gr

### DIFF
--- a/void-gr-filters.txt
+++ b/void-gr-filters.txt
@@ -786,6 +786,7 @@ skroutz.gr###sponsorship
 skroutz.gr##.s_call_to_action
 skroutz.gr##DIV[id="afc"]
 skroutz.gr##DIV[id="home_728x90"]
+skroutz.gr##.product-ad
 sport-fm.gr###backgroundlink
 sport-fm.gr##.textlinks
 sport-fm.gr##A.banner


### PR DESCRIPTION
Removes the banner ad column between store prices.
![skroutz_rule](https://user-images.githubusercontent.com/15065804/70853375-e352f500-1eb5-11ea-920d-cd925a71af14.png)
