### PR TITLE
Added 5 entries

### DIFF
--- a/void-gr-filters.txt
+++ b/void-gr-filters.txt
@@ -793,6 +793,8 @@ popaganda.gr##.banner
 popaganda.gr##.big-banner-top
 popaganda.gr##.main-margin.container > .newstrack-content.row > .post-margin-right.col-xs-8.col-md-8 > .waypoints.post-content > .affiliate > .textwidget
 prismanews.gr##.banneritem
+real.gr###realTopBanner
+real.gr###realTopBannerGap
 realestatenews.gr###right_col
 realestatenews.gr##.gk_tab_container0-style1
 realestatenews.gr##.gk_tab_wrap-style1
@@ -855,6 +857,9 @@ sport24.gr##A[href*="mens-x.gr"]
 sport24.gr##A[href*="www.bwin.com"]
 sport24.gr##DIV.code.currentArea-logo
 sport24.gr##div.ad
+sport24.gr#?##hp-readmore-cross-article .article:-abp-has(.byline_date:-abp-contains(ADVERTORIAL))
+sport24.gr##div[id^=ENGAGEYA]
+sport24.gr###page > .content-top-wrap
 sportdog.gr###block-views-promoted_companies-block_1
 sports.in.gr###RightBanner3
 sports.in.gr###RightBanner7


### PR DESCRIPTION
Most of them removes placeholders, with one entry removing adticles from `Sport24`. Directly inspired by https://github.com/uBlockOrigin/uAssets/issues/7607.

Example pages:
```
! https://www.real.gr/athlitismos/arthro/pio_konta_ston_ypobibasmo_h_magiorka_binteo-649594/
real.gr###realTopBanner
real.gr###realTopBannerGap

! https://www.sport24.gr/football/Spain/PrimeraDivision/thelta-mpartselona-2-2-odynhrh-gkela-gia-toys-mplaoygkrana.5725766.html
sport24.gr#?##hp-readmore-cross-article .article:-abp-has(.byline_date:-abp-contains(ADVERTORIAL))
sport24.gr##div[id^=ENGAGEYA]
sport24.gr###page > .content-top-wrap
```