### PR TITLE
Add rule for indusviva.com

### DIFF
--- a/void-gr-filters.txt
+++ b/void-gr-filters.txt
@@ -958,6 +958,7 @@ www.contra.gr##[href*="adman.gr"]
 www.news247.gr##[href*="bit.ly"]
 !Anti-Phishing Rules
 goldenconcept.ir^$document
+indusviva.com^$document
 ! Exception Rules
 @@contra.gr/XML/sponsors/pokergr/ilika/*_image.png
 @@contra.gr/XML/sponsors/pokergr/ilika/fasa_bg.jpg


### PR DESCRIPTION
Blocked Alpha Bank Phishing Website.
![Screenshot 2020-08-07 at 10 54 21](https://user-images.githubusercontent.com/15065804/89623330-1ca10080-d89d-11ea-8c1e-69146f394c49.png)
