### PR TITLE
Fix gameover.gr articles

### DIFF
--- a/void-gr-filters.txt
+++ b/void-gr-filters.txt
@@ -995,6 +995,7 @@ indusviva.com^$document
 ! Exceptions to element hiding
 ~aggeliestanea.gr##.adResult
 ~athensmagazine.gr##.ad_wrapper
+~gameover.gr##.share-container
 ~rockinathens.gr##.share-container
 ~www.ediva.gr##.pub_300x250
 ~www.ediva.gr##.pub_300x250m


### PR DESCRIPTION
The main text in each article is currently being hidden if this list is enabled, and cosmetic filtering is also enabled. The body of each article is inside a `share-container`.

I hope this is the correct way of fixing it. I'm not familiar with rules and I don't see any rule blocking `share-container`s, so I assume the `~rockinathens.gr##.share-container` line blocks any `share-container` but the one from rockinathens. If that is the case perhaps it would be better to remove the rockinathens.gr rule instead, since it is likely that other pages will use the same layout with the main text inside a `share-container` element.