### PR TITLE
Added rules for sexgr.net

### DIFF
--- a/void-gr-filters.txt
+++ b/void-gr-filters.txt
@@ -154,6 +154,7 @@ zougla.gr/uploads/thomas/travel_city_banner*
 ||bourdela.com/studiobanners/*
 ||call.thebutterfly.eu/Snippet/
 ||call.theowl.gr
+||cdn-gr.sexgr.net/b/*$image
 ||cdn.cnngreece.gr/media/com_news/ads/*$image
 ||cdn.cnngreece.gr/media/com_news/ads/4/skin_new_cosmote_2.jpg
 ||cdn.cnngreece.gr/templates/kgt_cnn/images/sponsors/videobox_1800x900.png
@@ -820,6 +821,7 @@ serraikanea.gr###sp-left
 serraikanea.gr###sp-right
 serraikanea.gr##.sp-page-title
 serraikanea.gr##.sppb-section-content-center
+sexgr.net#?#.left-col:-abp-has(h3:-abp-contains(Advertise))
 sfl.com.gr##DIV.banner-side
 sfl.com.gr##DIV[style="width: 285px; float: right; overflow: hidden;"]
 shopping.pathfinder.gr###box-sponsors
@@ -995,6 +997,7 @@ indusviva.com^$document
 ! Exceptions to element hiding
 ~aggeliestanea.gr##.adResult
 ~athensmagazine.gr##.ad_wrapper
+~sexgr.net##.ad-box
 ~www.ediva.gr##.pub_300x250
 ~www.ediva.gr##.pub_300x250m
 ~www.ediva.gr##.pub_728x90

--- a/void-gr-filters.txt
+++ b/void-gr-filters.txt
@@ -997,7 +997,6 @@ indusviva.com^$document
 ! Exceptions to element hiding
 ~aggeliestanea.gr##.adResult
 ~athensmagazine.gr##.ad_wrapper
-~sexgr.net##.ad-box
 ~www.ediva.gr##.pub_300x250
 ~www.ediva.gr##.pub_300x250m
 ~www.ediva.gr##.pub_728x90


### PR DESCRIPTION
Fix #107

### 1)
- for ads:
`sexgr.net#?#.left-col:-abp-has(h3:-abp-contains(Advertise))` can be simpler: 
`sexgr.net#?#.left-col:-abp-contains(Advertise)`
but I've decided to stick to the former, because I saw similiar:
https://github.com/kargig/greek-adblockplus-filter/blob/7ff294f17e77c3df831ca211f2715727979da7e4/void-gr-filters.txt#L876 so I've decided to follow the same scheme...feel free to decide which one you prefer, as I've been unable to determine which one fits you better.
### 2) 
- further blocking ads `||cdn-gr.sexgr.net/b/*$image` for greater efficiency, especially I've seen similiar filters on the filter list: https://github.com/kargig/greek-adblockplus-filter/blob/7ff294f17e77c3df831ca211f2715727979da7e4/void-gr-filters.txt#L157
https://github.com/kargig/greek-adblockplus-filter/blob/7ff294f17e77c3df831ca211f2715727979da7e4/void-gr-filters.txt#L142
### 3) obsolete - as it has been fixed in EasyList https://github.com/easylist/easylist/commit/3b59b6f92d1a7f344fc502ebcd428f55fbe592fc
- `~sexgr.net##.ad-box` a temporary unbreak for Easylist https://github.com/easylist/easylist/issues/9190 as nobody knows if / when they will fix it in EasyList, feel free to remove it later if it gets fixed in EasyList, 
- also again: I've wanted to use `sexgr.net#@#.ad-box` but I've seen saw that at the end of the filter list preferred exceptions are with `~` , so I've decided to follow the scheme, feel free to decide which one you prefer, as I was unable to determine which one fits you better.