### PR TITLE
Remove news247.gr empty ad frames.

### DIFF
--- a/void-gr-filters.txt
+++ b/void-gr-filters.txt
@@ -750,6 +750,8 @@ news247.gr###mainContent > .alpha.grid_12 > .main.default.stories:nth-of-type(4)
 news247.gr###mainContent > .alpha.grid_12 > .main.default.stories:nth-of-type(5)
 news247.gr###mainContent > .alpha.grid_12 > .main.default.stories:nth-of-type(6)
 news247.gr###mainContent > .alpha.grid_12 > .main.default.stories:nth-of-type(8)
+news247.gr##.adSlot-height--premium.code-widget
+news247.gr##.minHeight--400
 news247.gr##.seatimage
 news247.gr##DIV[class=dheadRightBoxBot]
 news247.gr##div[class="banner"]


### PR DESCRIPTION
Remove empty ad frames from news247.gr located on main page header and around article content.