### PR TITLE
added sponsored listings filter for skroutz.gr

### DIFF
--- a/void-gr-filters.txt
+++ b/void-gr-filters.txt
@@ -853,6 +853,7 @@ skroutz.gr##.s_call_to_action
 skroutz.gr##DIV[id="afc"]
 skroutz.gr##DIV[id="home_728x90"]
 skroutz.gr##.product-ad
+skroutz.gr##.selected-product-cards
 sport-fm.gr###backgroundlink
 sport-fm.gr##.textlinks
 sport-fm.gr##A.banner


### PR DESCRIPTION
Αναφέρουν ξεκάθαρα ότι σε αυτό το section προβάλλονται μόνο διαφημιζόμενα καταστήματα, ενώ παρακάτω βρίσκονται όλα τα καταστήματα
![Screenshot from 2023-07-13 12-20-39](https://github.com/kargig/greek-adblockplus-filter/assets/2352509/a5e22d95-ad03-48da-ac34-5f1eba1c597f)

Fixes: #117 